### PR TITLE
Fixed typo in jquery.ddslick.js

### DIFF
--- a/jquery.ddslick.js
+++ b/jquery.ddslick.js
@@ -98,7 +98,7 @@
                 else options.data = $.merge(ddSelect, options.data);
 
                 //Replace HTML select with empty placeholder, keep the original
-                var original = obj, placeholder = $('<div').attr('id', obj.attr('id') + '-dd-placeholder');
+                var original = obj, placeholder = $('<div>').attr('id', obj.attr('id') + '-dd-placeholder');
                 obj.replaceWith(placeholder);
                 obj = placeholder;
 


### PR DESCRIPTION
This typo caused problems in uncompressed version of the plugin.

Funny thing is that minified version is working fine.
